### PR TITLE
Fix libusbx 404

### DIFF
--- a/gphoto2-updater.sh
+++ b/gphoto2-updater.sh
@@ -75,7 +75,7 @@ echo "Downloading libusb 1.0.17"
 echo "-------------------------"
 echo
 
-if wget -q http://ftp.de.debian.org/debian/pool/main/libu/libusbx/libusbx_1.0.17.orig.tar.bz2
+if wget -q https://download.nus.edu.sg/mirror/ubuntu/pool/main/libu/libusbx/libusbx_1.0.17.orig.tar.bz2
 	then
 		tar xjvf libusbx_1.0.17.orig.tar.bz2
 		cd libusbx-1.0.17/


### PR DESCRIPTION
For some reason the current URL leads to 404 not found page, I've updated url in the code to make it point onto mirror on which we still can find it.