### PR TITLE
Missing dependencies for Ubuntu

### DIFF
--- a/gphoto2-updater.sh
+++ b/gphoto2-updater.sh
@@ -56,7 +56,7 @@ echo "Installing dependencies"
 echo "-----------------------"
 echo
 
-apt-get install -y build-essential libltdl-dev libusb-dev libexif-dev libpopt-dev libudev-dev
+apt-get install -y build-essential libltdl-dev libusb-dev libexif-dev libpopt-dev libudev-dev pkg-config
 
 echo
 echo "-------------------------"


### PR DESCRIPTION
./configure for libgphoto2 stops with an error "Build requires pkg-config" before this commit. I have not tested on rpi, but I believe this package will be installed already, so it will not add any extra packages then.