### PR TITLE
Update to 2.5.12

### DIFF
--- a/gphoto2-updater.sh
+++ b/gphoto2-updater.sh
@@ -132,7 +132,7 @@ echo "Removing gphoto2 and libgphoto2 if exists"
 echo "-----------------------------------------"
 echo
 
-apt-get remove -y gphoto2 libgphoto2-port10
+apt-get remove -y gphoto2 libgphoto2*
 
 echo
 echo "-----------------------"

--- a/gphoto2-updater.sh
+++ b/gphoto2-updater.sh
@@ -31,8 +31,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-latest_stable_version=2_5_10
-display_version=$(echo ${latest_stable_version} | tr '_' '.')
+latest_stable_libgphoto_version=2_5_12
+latest_stable_gphoto_version=2_5_11
+display_version=$(echo "libgphoto ${latest_stable_libgphoto_version}; gphoto ${latest_stable_gphoto_version}" | tr '_' '.')
 branch_libgphoto=''
 branch_gphoto=''
 
@@ -68,8 +69,8 @@ do
     case "$1" in
         -h|--help)          usage;;
         -d|--development)   shift 1;;
-        -s|--stable)        branch_libgphoto="--branch libgphoto2-${latest_stable_version}-release"
-                            branch_gphoto="--branch gphoto2-${latest_stable_version}-release"
+        -s|--stable)        branch_libgphoto="--branch libgphoto2-${latest_stable_libgphoto_version}-release"
+                            branch_gphoto="--branch gphoto2-${latest_stable_gphoto_version}-release"
                             shift 1;;
         --)                 break ;;
     esac
@@ -96,8 +97,8 @@ do
 						echo
             echo "\"Install last stable release (${display_version})\" selected"
 						echo
-						branch_libgphoto="--branch libgphoto2-${latest_stable_version}-release"
-						branch_gphoto="--branch gphoto2-${latest_stable_version}-release"
+						branch_libgphoto="--branch libgphoto2-${latest_stable_libgphoto_version}-release"
+						branch_gphoto="--branch gphoto2-${latest_stable_gphoto_version}-release"
 						break
             ;;
         "Quit")


### PR DESCRIPTION
Gphtoto2 was not updated so I had to split them into separate variables. I also made the libgphoto2 removal a bit more robust to remove any other potentially conflicting packages. Finally, a reminder that #45 should also be pulled.