### PR TITLE
Automated Testing and Update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,37 @@
 language: c
 compiler: gcc
 dist: trusty
+sudo: required
+
+services:
+  - docker
 
 env:
   global:
-    - GPHOTO2_VERSION="2\\.5\\.15"
-    - LIBGPHOTO2_VERSION="2\\.5\\.15"
+    - GPHOTO2_VERSION='2\.5\.15'
+    - LIBGPHOTO2_VERSION='2\.5\.15'
+    
+    - INSTALL_CMD="apt-get -qq update && apt-get -y install wget ca-certificates && wget https://raw.githubusercontent.com/$TRAVIS_REPO_SLUG/$TRAVIS_BRANCH/gphoto2-updater.sh && chmod +x gphoto2-updater.sh && ./gphoto2-updater.sh --stable"
+    - GPHOTO2_TEST_CMD="gphoto2 --version | grep '^gphoto2\\s\+$GPHOTO2_VERSION\\s'"
+    - LIBGPHOTO2_TEST_CMD="gphoto2 --version | grep '^libgphoto2\\s\+$LIBGPHOTO2_VERSION\\s'"
 
-install:
-  - sudo $TRAVIS_BUILD_DIR/gphoto2-updater.sh --stable
-
-script:
-  - gphoto2 --version | grep "^gphoto2\\s\+$GPHOTO2_VERSION\\s"
-  - gphoto2 --version | grep "^libgphoto2\\s\+$LIBGPHOTO2_VERSION\\s"
+jobs:
+  include:
+      - stage: Ubuntu 16.04
+        install:
+          - sudo $TRAVIS_BUILD_DIR/gphoto2-updater.sh --stable
+        script:
+          - eval "$GPHOTO2_TEST_CMD"
+          - eval "$LIBGPHOTO2_TEST_CMD"
+      - stage: Ubuntu 14.04
+        before_install: docker pull ubuntu:14.04
+        script: docker run -u root ubuntu:14.04 /bin/bash -c "$INSTALL_CMD && $GPHOTO2_TEST_CMD && $LIBGPHOTO2_TEST_CMD"
+      - stage: Debian 7
+        before_install: docker pull debian:7
+        script: docker run -u root debian:7 /bin/bash -c "$INSTALL_CMD && $GPHOTO2_TEST_CMD && $LIBGPHOTO2_TEST_CMD"
+      - stage: Debian 8
+        before_install: docker pull debian:8
+        script: docker run -u root debian:8 /bin/bash -c "$INSTALL_CMD && $GPHOTO2_TEST_CMD && $LIBGPHOTO2_TEST_CMD"
+      - stage: Debian 9
+        before_install: docker pull debian:9
+        script: docker run -u root debian:9 /bin/bash -c "$INSTALL_CMD && $GPHOTO2_TEST_CMD && $LIBGPHOTO2_TEST_CMD"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ dist: trusty
 
 env:
   global:
-    - GPHOTO2_VERSION="2\\.5\\.14"
-    - LIBGPHOTO2_VERSION="2\\.5\\.14"
+    - GPHOTO2_VERSION="2\\.5\\.15"
+    - LIBGPHOTO2_VERSION="2\\.5\\.15"
 
 install:
   - sudo $TRAVIS_BUILD_DIR/gphoto2-updater.sh --stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: c
+compiler: gcc
+dist: trusty
+
+env:
+  global:
+    - GPHOTO2_VERSION="2\\.5\\.14"
+    - LIBGPHOTO2_VERSION="2\\.5\\.14"
+
+install:
+  - sudo $TRAVIS_BUILD_DIR/gphoto2-updater.sh --stable
+
+script:
+  - gphoto2 --version | grep "^gphoto2\\s\+$GPHOTO2_VERSION\\s"
+  - gphoto2 --version | grep "^libgphoto2\\s\+$LIBGPHOTO2_VERSION\\s"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Gphoto2 and libGphoto2 compiler and installer script
 http://github.com/gonzalo/gphoto2-updater
 
 This script allows to install last development and last
-stable (2.5.14) releases of gphoto2 and libgphoto2 based on
+stable (2.5.15) releases of gphoto2 and libgphoto2 based on
 [git repositories](https://github.com/gphoto/)
 
 This script was initially created for Raspbian http://www.raspbian.org

--- a/gphoto2-updater.sh
+++ b/gphoto2-updater.sh
@@ -31,8 +31,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-latest_stable_libgphoto_version=2_5_14
-latest_stable_gphoto_version=2_5_14
+latest_stable_libgphoto_version=2_5_15
+latest_stable_gphoto_version=2_5_15
 display_version=$(echo "libgphoto ${latest_stable_libgphoto_version}; gphoto ${latest_stable_gphoto_version}" | tr '_' '.')
 branch_libgphoto=''
 branch_gphoto=''


### PR DESCRIPTION
This updates gphoto2 and libgphoto2 to version 2.5.15. Additionally, it adds automated testing through [Travis CI](https://travis-ci.org) on the following distributions (with the help of Docker):
- Ubuntu: 14.04 (Trusty Tahr), 16.04 (Xenial Xerus)
- Debian: 7 (Wheezy), 8 (Jessie), 9 (Stretch)

It will run the installer script (stable only) on each of these distros and will check to make sure that the right version has been successfully installed. Unfortunately because of the different architecture, it makes it very difficult to run automated test for Raspbian. I even surprised myself when I actually got it to work using a Docker image with QEMU, however the compilation was too slow and it timed out after Travis's 50 minute time limit for jobs. Here is the code for future reference:
```yaml
      - stage: Raspbian Lite Latest (QEMU)
        before_install: 
          - wget "https://downloads.raspberrypi.org/raspbian_lite_latest"
          - unzip raspbian_lite_latest -d raspbian_lite_image
          - mv raspbian_lite_image/*.img raspbian_lite_image/raspbian_lite.img
          - docker pull ryankurte/docker-rpi-emu:latest
          - sudo apt-get -qq update
          - sudo apt-get install -y qemu qemu-user-static
        script:
          - echo "$INSTALL_CMD && $GPHOTO2_TEST_CMD && LIBGPHOTO2_TEST_CMD" | docker run -i --privileged=true -v $(pwd)/raspbian_lite_image:/usr/rpi/images -w /usr/rpi ryankurte/docker-rpi-emu /bin/bash -c './run.sh images/raspbian_lite.img'
```

In order to enable the automated testing on this repository, you will need to log into the Travis CI website and enable it for this repository.