### PR TITLE
Remove -y argument from "apt-get remove"

### DIFF
--- a/gphoto2-updater.sh
+++ b/gphoto2-updater.sh
@@ -133,7 +133,7 @@ echo "Removing gphoto2 and libgphoto2 if exists"
 echo "-----------------------------------------"
 echo
 
-apt-get remove -y gphoto2 libgphoto2*
+apt-get remove gphoto2 libgphoto2*
 
 echo
 echo "-----------------------"


### PR DESCRIPTION
Let the user validate what is going to be deleted.
Drawback: no longer one shot, user must confirm each time in the middle of the script
But on the other side the script will stop removing package like ubuntu-desktop, blender, shotwell... without asking the user if he really want to do that.

(even if the package is not removed installation run fine, even if everything may not link to the lastest version)

related issue: #57 