### PR TITLE
Fixes #70 libgphoto not being updated to the latest version

### DIFF
--- a/gphoto2-updater.sh
+++ b/gphoto2-updater.sh
@@ -170,7 +170,7 @@ echo "-----------------------------------"
 echo
 
 autoreconf --install --symlink
-./configure
+./configure --libdir= /usr/lib/arm-linux-gnueabihf/
 make -j "$cores"
 make install
 cd ..
@@ -198,7 +198,7 @@ echo "--------------------------------"
 echo
 
 autoreconf --install --symlink
-./configure
+./configure --libdir= /usr/lib/arm-linux-gnueabihf/
 make -j "$cores"
 make install
 cd ..


### PR DESCRIPTION
Add libdir option as proposed in #70 by Seeelefant to also update libgphoto to the same version as gphoto2.